### PR TITLE
ensure sections have names to allow loading to ghidra

### DIFF
--- a/isfb_parser/isfb_to_pe.cpp
+++ b/isfb_parser/isfb_to_pe.cpp
@@ -98,10 +98,17 @@ size_t realign_sections(IN const isfb_hdr &hdr, IN OUT IMAGE_NT_HEADERS_T* nt_hd
 
 	IMAGE_SECTION_HEADER* sec_ptr = (IMAGE_SECTION_HEADER*)((BYTE*)&nt_hdr->OptionalHeader + nt_hdr->FileHeader.SizeOfOptionalHeader);
 
+	char name[IMAGE_SIZEOF_SHORT_NAME] = ".adata";
+	int n = 0;
 	for (size_t i = 0; i < hdr.sections_count; i++) {
 		//std::cout << "section: " << std::hex << sec_ptr[i].PointerToRawData << "\n";
 		if (!validate_ptr(buf, buf_size, &sec_ptr[i], sizeof(IMAGE_SECTION_HEADER))) {
 			break;
+		}
+		if (sec_ptr[i].Name[0] == '\0')
+		{
+			memcpy(sec_ptr[i].Name, name, sizeof(name));
+			name[1] = 'a' + ((++n) % ('z' - 'a'));
 		}
 		sec_ptr[i].VirtualAddress = hdr.sections[i].virtual_offset;
 		sec_ptr[i].PointerToRawData = hdr.sections[i].virtual_offset;


### PR DESCRIPTION
PE files converted from PX could not be loaded to ghidra since the section names were blank.
I added code to ensure section names are present.